### PR TITLE
set mongo host to work

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,9 +9,9 @@ DEBUG = True
 #Mongo Finance Config
 MONGO_PORT = 27017
 MONGO_DBNAME = 'finance'
-MONGO_HOST = os.environ['DB_PORT_27017_TCP_ADDR']
+MONGO_HOST = "db" 
 
 #Mongo Config
 MONGO2_PORT = 27017
 MONGO2_DBNAME = 'config'
-MONGO_HOST = os.environ['DB_PORT_27017_TCP_ADDR']
+MONGO_HOST = "db" 

--- a/app/config.py
+++ b/app/config.py
@@ -14,4 +14,4 @@ MONGO_HOST = "db"
 #Mongo Config
 MONGO2_PORT = 27017
 MONGO2_DBNAME = 'config'
-MONGO_HOST = "db" 
+MONGO2_HOST = "db" 


### PR DESCRIPTION
The hostname of the mongo container will be “db” (because thats the
name of it in the docker-compose file). This change tells the
application that